### PR TITLE
Hack card fix

### DIFF
--- a/src/components/OpponentStacks.vue
+++ b/src/components/OpponentStacks.vue
@@ -8,7 +8,7 @@
         </a>
       </h4>
     </div>
-    <div :id="'collapse'+ player.id" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
+    <div :id="'collapse'+ player.id" class="panel-collapse" :class="collapseState" role="tabpanel" aria-labelledby="headingThree">
       <div class="panel-body">
         <div class="well">
           <h6>True Stacks</h6>
@@ -70,6 +70,8 @@ export default {
   data () {
     return {
       title: 'Opponent Stacks',
+      hackIsActive: false,
+      currentCard: this.$store.getters.getActiveCard
     }
   },
   computed: {
@@ -84,11 +86,25 @@ export default {
     },
     score() {
      return this.player.score
+    },
+    collapseState() {
+      if(this.$store.getters.getActiveCard !== undefined) {
+        return {
+          'collapse in': this.$store.getters.getActiveCard.type === 'H',
+          collapse: this.$store.getters.getActiveCard.type !== 'H'
+        }
+      } else {
+        return {
+          collapse: true
+        }
+      }
     }
   },
+
   components: {
       'opponent-stack': OpponentStack
   },
+
   methods: {
     hackStack(e) {
       console.log('hack attempted on stack', e)

--- a/src/components/OpponentStacks.vue
+++ b/src/components/OpponentStacks.vue
@@ -70,8 +70,6 @@ export default {
   data () {
     return {
       title: 'Opponent Stacks',
-      hackIsActive: false,
-      currentCard: this.$store.getters.getActiveCard
     }
   },
   computed: {

--- a/src/components/OpponentStacks.vue
+++ b/src/components/OpponentStacks.vue
@@ -8,7 +8,7 @@
         </a>
       </h4>
     </div>
-    <div :id="'collapse'+ player.id" class="panel-collapse" :class="collapseState" role="tabpanel" aria-labelledby="headingThree">
+    <div :id="'collapse'+ player.id" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
       <div class="panel-body">
         <div class="well">
           <h6>True Stacks</h6>
@@ -86,18 +86,6 @@ export default {
     },
     score() {
      return this.player.score
-    },
-    collapseState() {
-      if(this.$store.getters.getActiveCard !== undefined) {
-        return {
-          'collapse in': this.$store.getters.getActiveCard.type === 'H',
-          collapse: this.$store.getters.getActiveCard.type !== 'H'
-        }
-      } else {
-        return {
-          collapse: true
-        }
-      }
     }
   },
 

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -175,6 +175,7 @@ export default {
     cardClicked (c) {
       // alert('cardId of clicked card is ' + cardId)
       console.log(c.id)
+      bus.$emit('currentCardIs', c);
       this.tipsCardSelected = this.setTipBox(c);
       let prevActive = this.$store.getters.getActiveCard
 
@@ -184,6 +185,9 @@ export default {
           this.$store.commit('removeAllSelectedStacks')
           this.$store.commit('setStackSelectedBoolean', {payload: undefined})
         }
+      }
+      if(c.type === 'H') {
+        console.log('HACK');
       }
 
 

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -175,7 +175,6 @@ export default {
     cardClicked (c) {
       // alert('cardId of clicked card is ' + cardId)
       console.log(c.id)
-      bus.$emit('currentCardIs', c);
       this.tipsCardSelected = this.setTipBox(c);
       let prevActive = this.$store.getters.getActiveCard
 
@@ -186,12 +185,6 @@ export default {
           this.$store.commit('setStackSelectedBoolean', {payload: undefined})
         }
       }
-      if(c.type === 'H') {
-        console.log('HACK');
-      }
-
-
-      setTimeout(() => document.addEventListener('click', this.deselectAll), 0)
     },
     setTipBox(c) {
         switch(c.type) {
@@ -271,9 +264,6 @@ export default {
     setActiveCard(c) {
 
       this.$store.commit('selectCard', c)
-
-      setTimeout(() => document.addEventListener('click', this.deselectAll), 0)
-
       console.log('active card set by dragging')
     }
   },


### PR DESCRIPTION
Removed `setTimeout(() => document.addEventListener('click', this.deselectAll), 0)` which would deselect the card if clicked anywhere on the screen. Can now have Hack card (or any card) selected than click on the opponent stack without having the card deselect. 
fix #54 