### PR TITLE
End turn

### DIFF
--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -1,5 +1,14 @@
 <template>
   <div id="maincontainer">
+
+    <div id="playerTurn" class="modal fade yourTurn" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <h4 class="modal-title">{{ activePlayer }}, It's Your Turn</h4>
+        </div>
+      </div>
+    </div>
+
     <div id="header">
       <p>Programming Wars</p>
       <div style="margin-left: auto; padding: 0 10px 0 0">
@@ -74,16 +83,14 @@ export default {
       modalId: "gameOverModal",
       creditsModal: "creditsModal",
       creditsModalTitle: "Programming Wars Credits and Change Log",
-      tipsToggle: true
+      tipsToggle: true,
+      activePlayer: ''
     }
   },
   methods: {
     toggleTipBox() {
       bus.$emit('tipsToggled');
     },
-      showCredits() {
-
-      },
     submit() {
         console.log(this.newPlayer)
         if(this.newPlayer.length > 0 && this.localPlayers.indexOf(this.newPlayer) < 0) {
@@ -151,6 +158,7 @@ export default {
         for (let player of players) {
           if (player.score >= this.scoreLimit) {
             console.log('game over')
+            bus.$emit('playerWins');
 
             this.gameOverWinner = "Congratulations " + player.name + ", you win!"
             this.gameOverText = player.name + " wins!"
@@ -160,6 +168,9 @@ export default {
               console.log('removing event listener')
             })
             clearInterval(gameEventLoopTimer);
+          } else {
+            this.activePlayer = this.$store.getters.currentPlayerName;
+            $('#playerTurn').modal();
           }
         }
       });

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -25,7 +25,8 @@
         </div>
         <div class="modal-footer">
           <button v-if="cancel" type="button" class="btn btn-primary" data-dismiss="modal">Cancel</button>
-          <button type="button" class="btn btn-primary" data-dismiss="modal" @click="modalCallback">OK</button>
+          <button type="button" class="btn btn-primary" data-dismiss="modal" @click="okBtn">OK</button>
+
         </div>
       </div>
     </div>
@@ -36,6 +37,7 @@
 
   import { bus } from './Bus';
   import Card from './Card'
+  import Router from '../router/index'
 
 
   export default {
@@ -53,7 +55,14 @@
 
     },
     methods: {
-
+      okBtn() {
+        console.log(this.modalId);
+        if(this.modalId === 'creditsModal') {
+          return ''
+        } else {
+            this.$router.push('/')
+        }
+      }
     },
     components: {
         'card': Card

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -1,12 +1,12 @@
 <template>
-    <div id="player-info-panel">
+    <div id="player-info-panel" :hasPlayed="hasPlayed">
 
-      <modal modalId="discardCards" modalTitle="Cards in the Discard Pile" :modalBody="modalText" :modalCards="modalCards" :modalCallback="() => {}"></modal>
+      <modal modalId="discardCards" modalTitle="Cards in the Discard Pile" :modalBody="modalText" :modalCards="modalCards"></modal>
 
-      <h4 class="playerName"><b>{{ currentPlayerName }}</b>, It's Your Turn!</h4>
+      <h4 class="playerName" ><b>{{ currentPlayerName }}</b>, It's Your Turn!</h4>
       <div id="flexcontainer">
         <div id="tipBox" class="container" :style="displayStyle" :cardClicked="tipsCardSelected">
-          <div class="panel panel-default" style="border-radius: 10px">
+          <div class="panel panel-default" style="border-radius: 10px" >
             <div class="panel-heading" style="border-radius: 10px"><h5>{{ tipsCardSelected }}</h5></div>
             <div class="panel-body">{{ tipsInfoText }}</div>
           </div>
@@ -18,19 +18,15 @@
                   <card :cardData="card" v-on:cardClicked="cardClicked" @setActiveCard="setActiveCard"></card>
               </li>
           </ul>
-          <h4 class="boolState" >Active Side is: <div :class="changeTrueFalse"><b>{{ activeSide }}</b></div></h4>
+          <h4 class="boolState">Active Side is: <div :class="changeTrueFalse"><b>{{ activeSide }}</b></div></h4>
         </div>
 
         <div id="controls">
-
-        <button class="btn btn-primary endTurnButton" :class="hasPlayed" :disabled="endTurnEnabled" v-on:click="endTurn">
-        End Your Turn
-      </button>
-        <button class="btn btn-warning rightSide" v-on:click="discardSelected">
+        <button class="btn btn-warning rightSide" @click="discardSelected">
           Discard Selected Card
         </button>
 
-        <button class="btn btn-primary rightSide" v-on:click="displayDiscard">
+        <button class="btn btn-primary rightSide" @click="displayDiscard">
           Show Discarded Cards
         </button>
 
@@ -82,21 +78,13 @@ export default {
               return ""
       },
       hasPlayed() {
-        if (this.$store.getters.getHasPlayed)
-            return "hasPlayed"
+        if (this.$store.getters.getHasPlayed) {
+          this.endTurn();
+          return "hasPlayed"
+        }
         else
             return ""
       },
-    selectedCard () {
-      var selectedCard;
-      for (var card in this.cards) {
-        if (card.selected === true) {
-          selectedCard = card
-        }
-      }
-
-      return selectedCard
-    },
     hand() {
 
         let hand = this.$store.getters.getCurrentPlayerHand
@@ -116,15 +104,6 @@ export default {
     currentPlayerName() {
         let playerName = this.$store.getters.currentPlayerName;
         return playerName.charAt(0).toUpperCase() + playerName.slice(1).toLowerCase();
-    },
-    endTurnEnabled() {
-        let hasPlayed = this.$store.getters.getHasPlayed
-
-        if (hasPlayed) {
-            return false
-        } else {
-            return true
-        }
     },
     activeSide() {
         let activeSideString = String(this.$store.getters.getActiveSide)
@@ -299,12 +278,6 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-  .hasPlayed {
-    -webkit-box-shadow: 0px 0px 24px 4px rgba(0,255,60,1);
-    -moz-box-shadow: 0px 0px 24px 4px rgba(0,255,60,1);
-    box-shadow: 0px 0px 24px 4px rgba(0,255,60,1);
-  }
-
   #flexcontainer {
     width: 100%;
     display: flex;
@@ -316,12 +289,12 @@ export default {
   #controls {
     display: flex;
     flex-direction: column;
-    padding: 0px;
     justify-content: space-between;
     align-items: center;
     padding-right: 50px;
     flex-basis: content;
     flex-shrink:5;
+    margin-top: -120px;
   }
 
   #cards {
@@ -372,12 +345,6 @@ li {
 a {
   color: #42b983;
 }
-
-  .endTurnButton {
-    width: 200px;
-    height: 100px;
-  }
-
   .rightSide {
     float: right;
     margin-top: 20px;

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -2,14 +2,13 @@
     <div id="player-info-panel" :hasPlayed="hasPlayed">
 
       <modal modalId="discardCards" modalTitle="Cards in the Discard Pile" :modalBody="modalText" :modalCards="modalCards"></modal>
-      <div id="playerTurn" class="modal fade yourTurn" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content">
-            </button>
-              <h4 class="modal-title">{{ currentPlayerName }}, It's Your Turn</h4>
-          </div>
-        </div>
-      </div>
+      <!--<div id="playerTurn" class="modal fade yourTurn" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">-->
+        <!--<div class="modal-dialog" role="document">-->
+          <!--<div class="modal-content">-->
+              <!--<h4 class="modal-title">{{ currentPlayerName }}, It's Your Turn</h4>-->
+          <!--</div>-->
+        <!--</div>-->
+      <!--</div>-->
 
       <h4 class="playerName" ><b>{{ currentPlayerName }}</b>, It's Your Turn!</h4>
       <div id="flexcontainer">
@@ -50,6 +49,9 @@ import { bus } from './Bus';
 import Card from './Card'
 import Modal from './Modal'
 
+//Time in sec for the modal to stay up
+const displayTime = 1.5;
+
 export default {
   name: 'PlayerInfoPanel',
   data () {
@@ -88,8 +90,11 @@ export default {
       hasPlayed() {
         if (this.$store.getters.getHasPlayed) {
           this.endTurn();
-          $('#playerTurn').modal();
-          setTimeout(function() {$('#playerTurn').modal('hide');}, 1000);
+//          bus.$on('playerWins', () => {playerWins = true;});
+//          if(!playerWins){
+//            $('#playerTurn').modal();
+//            setTimeout(function() {$('#playerTurn').modal('hide');}, displayTime*1000);
+//          }
           return "hasPlayed"
         }
         else
@@ -360,6 +365,10 @@ a {
     margin-top: 20px;
   }
 
+.yourTurn {
+  position: absolute;
+  top: 350px;
+}
   .trueFalse {
 
     animation: cssAnimation 3s 16 ease-in-out;

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -2,6 +2,14 @@
     <div id="player-info-panel" :hasPlayed="hasPlayed">
 
       <modal modalId="discardCards" modalTitle="Cards in the Discard Pile" :modalBody="modalText" :modalCards="modalCards"></modal>
+      <div id="playerTurn" class="modal fade yourTurn" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+          <div class="modal-content">
+            </button>
+              <h4 class="modal-title">{{ currentPlayerName }}, It's Your Turn</h4>
+          </div>
+        </div>
+      </div>
 
       <h4 class="playerName" ><b>{{ currentPlayerName }}</b>, It's Your Turn!</h4>
       <div id="flexcontainer">
@@ -80,6 +88,8 @@ export default {
       hasPlayed() {
         if (this.$store.getters.getHasPlayed) {
           this.endTurn();
+          $('#playerTurn').modal();
+          setTimeout(function() {$('#playerTurn').modal('hide');}, 1000);
           return "hasPlayed"
         }
         else

--- a/src/components/SettingsComponent.vue
+++ b/src/components/SettingsComponent.vue
@@ -23,6 +23,7 @@
             <div id="scoreSelect">
             Score to Win:
             <select class="custom-select" name="select" v-model="selected">
+              <option value="2">TESTING</option>
               <option value="10">Short (score 10)</option>
               <option value="20">Medium (score 20)</option>
               <option value="30">Long (score 30)</option>


### PR DESCRIPTION
Removed the end turn button, now ends the turn once a player has added a card to stack or discarded a card. I also added a pop-up box showing who's turn it is to play once a turn has ended to make it more clear the turn is over. The pop-up box disappears after 1 sec. @johnanvik let me know what you think of this feature.