### PR TITLE
Shows name as it was entered 

### DIFF
--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -114,8 +114,7 @@ export default {
       return activePlayer + 1
     },
     currentPlayerName() {
-        let playerName = this.$store.getters.currentPlayerName;
-        return playerName.charAt(0).toUpperCase() + playerName.slice(1).toLowerCase();
+      return this.$store.getters.currentPlayerName;
     },
     endTurnEnabled() {
         let hasPlayed = this.$store.getters.getHasPlayed

--- a/src/components/SettingsComponent.vue
+++ b/src/components/SettingsComponent.vue
@@ -65,7 +65,7 @@
       }
     },
     methods: {
-      submit(e) {
+      submit() {
         console.log(this.newPlayer)
 
         if(this.newPlayer.length > 0 && this.localPlayers.indexOf(this.newPlayer) < 0) {


### PR DESCRIPTION
The player name is now always shown exactly as it was entered at the beginning of the game. Prevents two players from displaying the same name (example Vincent and vINCENT is allowed but in "___, its your turn" it would both show Vincent).

fix #55 