### PR TITLE
Changed/added error messages

### DIFF
--- a/src/components/Stack.vue
+++ b/src/components/Stack.vue
@@ -257,7 +257,7 @@ export default {
 
             } else {
               // for now, showing alert
-                  $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add an instruction card to a non-empty stack. Try adding that card to a different stack." );
+                  $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add an instruction card to a non-empty stack. Try adding that card to a new stack." );
 
                   $('button[stackId="'+this.stackId+'"]').popover('toggle')
             }
@@ -281,7 +281,12 @@ export default {
               this.$store.commit('setHasPlayed', {hasPlayed: true})
 
 
-            } else {
+            }else if(thisStack.stackTopCard().type === 'R') {
+              $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to another repetition card. Try adding that card to a stack with an Instruction or Group card." );
+              $('button[stackId="'+this.stackId+'"]').popover('toggle')
+
+            }
+            else {
 
                   $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to a stack without an Instruction or Group card. Try adding that card to a stack with an Instruction or Group card." );
 
@@ -297,7 +302,7 @@ export default {
             console.log('current active card: ' + this.$store.getters.getActiveCard)
           if (thisStack.cards.length === 0) {
 
-                $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a variable card to a stack without an instruction card. Try adding that card to a stack with an instruction card." );
+                $('button[stackId="'+this.stackId+'"]').attr("data-content", "You can only add variable cards to a stack with an open variable (Rx) repetition card or an existing variable card." );
 
 
                 $('button[stackId="'+this.stackId+'"]').popover('toggle')
@@ -326,7 +331,7 @@ export default {
 
 
             } else {
-                $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a variable card to a stack without a Variable (Rx) repetition card. Try adding that card to a stack with an variable Repetition Card (Rx)." );
+                $('button[stackId="'+this.stackId+'"]').attr("data-content", "You can only add variable cards to a stack with an open variable (Rx) repetition card or an existing variable card." );
 
 
                 $('button[stackId="'+this.stackId+'"]').popover('toggle')
@@ -334,6 +339,15 @@ export default {
 
 
               break;
+
+          case 'H':
+            $('button[stackId="'+this.stackId+'"]').attr("data-content", "Hack cards are not played on a stack, you must open the opponent's stack to hack them." );
+            $('button[stackId="'+this.stackId+'"]').popover('toggle');
+            break;
+
+          case 'G':
+            $('button[stackId="'+this.stackId+'"]').attr("data-content", "Group cards are not played on a stack, click the checkbox(s) to group the cards together (the combined value of the stack(s) must equal the value of the group card)." );
+            $('button[stackId="'+this.stackId+'"]').popover('toggle');
 
           default:
               console.log('unknown card type')

--- a/src/components/Stack.vue
+++ b/src/components/Stack.vue
@@ -257,7 +257,7 @@ export default {
 
             } else {
               // for now, showing alert
-                  $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add an instruction card to a non-empty stack. Try adding that card to a new stack." );
+                  $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add an instruction card to a non-empty stack. Instead add the card to a new stack" );
 
                   $('button[stackId="'+this.stackId+'"]').popover('toggle')
             }
@@ -268,7 +268,7 @@ export default {
             console.log('current active card: ' + this.$store.getters.getActiveCard)
 
             if (thisStack.cards.length === 0) {
-              $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to a stack without an instruction card. Try adding that card to a stack with an instruction card." );
+              $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to a stack without an instruction card. Instead add the card to a stack with an instruction card." );
               $('button[stackId="'+this.stackId+'"]').popover('toggle')
             } else if (thisStack.stackTopCard().type === 'I' || thisStack.stackTopCard().type === 'G') {
 
@@ -282,13 +282,13 @@ export default {
 
 
             }else if(thisStack.stackTopCard().type === 'R') {
-              $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to another repetition card. Try adding that card to a stack with an Instruction or Group card." );
+              $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to another repetition card. Instead add the card to a stack with an Instruction or Group card." );
               $('button[stackId="'+this.stackId+'"]').popover('toggle')
 
             }
             else {
 
-                  $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to a stack without an Instruction or Group card. Try adding that card to a stack with an Instruction or Group card." );
+                  $('button[stackId="'+this.stackId+'"]').attr("data-content", "You cannot add a repetition card to a stack without an Instruction or Group card. Instead add the card to a stack with an Instruction or Group card." );
 
                   $('button[stackId="'+this.stackId+'"]').popover('toggle')
             }
@@ -346,7 +346,7 @@ export default {
             break;
 
           case 'G':
-            $('button[stackId="'+this.stackId+'"]').attr("data-content", "Group cards are not played on a stack, click the checkbox(s) to group the cards together (the combined value of the stack(s) must equal the value of the group card)." );
+            $('button[stackId="'+this.stackId+'"]').attr("data-content", "Group cards are not played on a stack. Click the checkbox(es) to select the cards to group together. The total of the selected card(s) must equal the value of the group card." );
             $('button[stackId="'+this.stackId+'"]').popover('toggle');
 
           default:


### PR DESCRIPTION
I have changed some of the error messages to be more relevant to the particular move a player is attempting. I have also added error messages for the hack and group card in case a player tries to add them to a stack. @johnanvik please read over the messages carefully and advise if the text needs to be rewritten.

fix #39 