### PR TITLE
Group a single stack

### DIFF
--- a/src/components/Stack.vue
+++ b/src/components/Stack.vue
@@ -165,7 +165,7 @@ export default {
 
         let activeCardValue = this.$store.getters.getActiveCard.value
 
-        if (selectedStacks.length >= 2 && activeCardValue === totalScore) {
+        if (selectedStacks.length >= 1 && activeCardValue === totalScore) {
             $('#'+this.modalId2).modal('show')
         }
     },


### PR DESCRIPTION
The player can now group a single stack as long as it matches the value of the group card.

fix #41 