### PR TITLE
Game winner modal and next player modal conflict fix

### DIFF
--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -143,7 +143,8 @@ export default {
           if (player.score >= this.$store.getters.getScoreLimit) {
             this.gameOverWinner = "Congratulations " + player.name + ", you win!"
             this.gameOverText = player.name + " wins!"
-            $('#' + this.modalId).modal('show')
+            $('#' + this.modalId).modal('show');
+            this.$store.commit('setWinner', true);
 
             document.removeEventListener('click', () => {
               console.log('removing event listener')


### PR DESCRIPTION
For some reason one line was missing to set the bool variable of having a winner, this variable is set true when there is a winner preventing the next turn modal from showing up. 