### PR TITLE
Start new game after the winner modal is shown

### DIFF
--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -3,7 +3,7 @@
 
     <rules-modal id="rulesModal" class="modal fade rules" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" style="background-color: yellowgreen"></rules-modal>
     <credits-modal id="creditsModal" class="modal fade credits" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" style="background-color: mediumpurple"></credits-modal>
-    <winner-modal id="winnerModal" class="modal fade winner" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true"
+    <winner-modal id="winnerModal" class="modal fade winner" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" data-backdrop="static" data-keyboard="false"
     :winner="winner" :playerList="playerList" :winnerScore="winnerScore"></winner-modal>
 
     <div id="header">
@@ -75,11 +75,11 @@ export default {
       gameOverText: "",
       modalId: "gameOverModal",
       tipsToggle: true,
-      factsToggle: true,  
+      factsToggle: true,
       playerList: [],
       winner: '',
       winnerScore: 0
-      
+
     }
   },
   methods: {

--- a/src/components/WinnerModal.vue
+++ b/src/components/WinnerModal.vue
@@ -2,9 +2,8 @@
   <div>
     <div class="modal-dialog" role="document">
       <div class="modal-content">
-        <div class="modal-header">  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
+        <div class="modal-header"> <button type="button" class="close" data-dismiss="modal" aria-label="Close"><router-link to="/">
+          <span aria-hidden="true">&times;</span></router-link></button>
           <h3 class="modal-title"><b>Congratulations {{ winner }}!!</b></h3>
         </div>
         <div class="modal-body">


### PR DESCRIPTION
Clicking the "X" in the top right corner of the winner modal will now start a new game. Clicking outside of the modal will no longer close the modal. 

fix #108 