### PR TITLE
Added a discard button next to cancel in the hack modal

### DIFF
--- a/src/components/HackModal.vue
+++ b/src/components/HackModal.vue
@@ -22,6 +22,7 @@
 
         </div>
         <div class="modal-footer">
+          <button class="btn btn-default" @click="discardHack" data-dismiss="modal">Discard</button>
           <button type="button" class="btn btn-default" data-dismiss="modal" style="margin: 5px;" @click="hackCanceled">Cancel</button>
         </div>
       </div>
@@ -43,7 +44,14 @@
     methods: {
       hackCanceled() {
         bus.$emit('hackCanceled');
-      }
+      },
+      discardHack() {
+        if (this.$store.getters.getActiveCard !== undefined) {
+          this.$store.commit('discardSelectedCard');
+          this.$store.dispatch('playerTookTurn');
+          this.$store.dispatch('turn', true);
+        }
+      },
     },
     created() {
       $('.hack').modal({

--- a/src/components/HackModal.vue
+++ b/src/components/HackModal.vue
@@ -22,7 +22,7 @@
 
         </div>
         <div class="modal-footer">
-          <button class="btn btn-default" @click="discardHack" data-dismiss="modal">Discard</button>
+          <button class="btn btn-default" @click="discardHack" data-dismiss="modal">Discard Hack Card</button>
           <button type="button" class="btn btn-default" data-dismiss="modal" style="margin: 5px;" @click="hackCanceled">Cancel</button>
         </div>
       </div>

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -143,8 +143,6 @@ export default {
         this.$store.commit('discardSelectedCard');
         this.$store.dispatch('playerTookTurn');
         this.$store.dispatch('turn', true);
-//        this.$store.commit('checkWin');
-//        this.$store.dispatch('endTurn');
       }
     },
     cardClicked (c) {


### PR DESCRIPTION
The player can now choose to discard the hack card from the modal screen if desired. 

fix #134.