### PR TITLE
Fixed spaces in name for hack modal

### DIFF
--- a/src/components/HackModal.vue
+++ b/src/components/HackModal.vue
@@ -10,11 +10,11 @@
         <div class="modal-body">
           <div class="container">
             <ul class="nav nav-tabs" style="font-size: 25px">
-              <li v-for="player in players"><a data-toggle="tab" :href="'#' + player.name">{{ player.name }}</a></li>
+              <li v-for="player in players"><a data-toggle="tab" :href="'#' + player.id">{{ player.name }}</a></li>
             </ul>
 
             <div class="tab-content" style="text-align: left">
-              <div v-for="player in players" :id="player.name" class="tab-pane fade">
+              <div v-for="player in players" :id="player.id" class="tab-pane fade">
                 <opponent-stacks :player="player"></opponent-stacks>
             </div>
           </div>


### PR DESCRIPTION
The tabs and its content was populated by the player name therefore the space would cause an issue, it is now related based on the player id (1, 2, 3, or 4).
fix #125 