### PR TITLE
Changed modals to divs

### DIFF
--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -6,6 +6,9 @@
     <winner-modal id="winnerModal" class="modal fade winner" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true" data-backdrop="static" data-keyboard="false"
     :playerList="playerList"></winner-modal>
     <coin-modal id="coinModal" class="modal fade coin" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true"></coin-modal>
+    <transition name="fade">
+      <player-turn v-if="playerTurn"></player-turn>
+    </transition>
 
     <div id="header">
       <p>Programming Wars</p>
@@ -52,6 +55,7 @@ import CreditsModal from './CreditsModal.vue'
 import HackModal from './HackModal.vue'
 import WinnerModal from './WinnerModal.vue'
 import CoinModal from './CoinModal.vue'
+import PlayerTurn from './PlayerTurnPopUp.vue'
 
 
 import Card from '../classes/Card'
@@ -81,6 +85,19 @@ export default {
       winnerScore: 0,
 
     }
+  },
+  components: {
+    'player-info-panel': PlayerInfoPanel,
+    'playfield': Playfield,
+    'opponent-stacks': OpponentStacks,
+    'modal': Modal,
+    'rules-modal': RulesModal,
+    'credits-modal': CreditsModal,
+    'hack-modal': HackModal,
+    'winner-modal': WinnerModal,
+    'coin-modal': CoinModal,
+    'player-turn': PlayerTurn
+
   },
   methods: {
     submit() {
@@ -131,20 +148,12 @@ export default {
     },
     highlighted() {
         return 'box-shadow: 0 0 15px 10px forestgreen';
+    },
+    playerTurn() {
+      return this.$store.state.playerTurn;
     }
   },
-  components: {
-    'player-info-panel': PlayerInfoPanel,
-    'playfield': Playfield,
-    'opponent-stacks': OpponentStacks,
-    'modal': Modal,
-    'rules-modal': RulesModal,
-    'credits-modal': CreditsModal,
-    'hack-modal': HackModal,
-    'winner-modal': WinnerModal,
-    'coin-modal':CoinModal
 
-  },
   watch: {
     tipsToggle(val) {
         if(val === true && this.factsToggle === false) {
@@ -189,7 +198,6 @@ export default {
                   this.$store.commit('setActiveSide', {activeSide: false})
                 }
                 this.$store.dispatch('turn', false);
-//                this.$store.dispatch('coinFlipWinCheck');
               setTimeout(() => {
                 this.$store.commit('setTrueFalseAnim', {startAnim: false});
                 this.$store.commit('setGameState', {gameState: 'playerTurn'});
@@ -286,4 +294,20 @@ a {
   color: #fff;
 }
 
+  .fade-enter {
+    opacity: 0;
+  }
+
+  .fade-enter-active {
+    transition: opacity .5s;
+  }
+
+  .fade-leave {
+
+  }
+
+  .fade-leave-active {
+    transition: opacity .5s;
+    opacity: 0;
+  }
 </style>

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -1,13 +1,13 @@
 <template>
     <div id="player-info-panel">
 
-      <div id="playerTurn" class="modal fade yourTurn" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">
-        <div class="modal-dialog" role="document">
-          <div class="modal-content" style="border-radius: 30px">
-            <h4 class="modal-title">{{ currentPlayerName }}, It's Your Turn</h4>
-          </div>
-        </div>
-      </div>
+      <!--<div id="playerTurn" class="modal fade yourTurn" tabindex="-1" role="dialog" aria-labelledby="" aria-hidden="true">-->
+        <!--<div class="modal-dialog" role="document">-->
+          <!--<div class="modal-content" style="border-radius: 30px">-->
+            <!--<h4 class="modal-title">{{ currentPlayerName }}, It's Your Turn</h4>-->
+          <!--</div>-->
+        <!--</div>-->
+      <!--</div>-->
 
       <div id="flexcontainer">
         <div id="tipBox" class="container" :style="displayStyle" :cardClicked="tipsCardSelected">

--- a/src/components/PlayerTurnPopUp.vue
+++ b/src/components/PlayerTurnPopUp.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="screen">
+    <div class="container">
+      <div class="row">
+        <div class="col-lg-12 col-md-12 col-sm-12" id="playerTurn">
+          <h4 id="text">{{ currentPlayer }}, its your turn</h4>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    currentPlayer() {
+      return this.$store.getters.currentPlayerName
+    }
+  }
+}
+</script>
+
+<style>
+.screen {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+}
+
+  #playerTurn {
+    border-radius: 30px;
+    width: 500px;
+    height: 50px;
+    position: fixed;
+    top:35%;
+    left: 50%;
+    margin-left: -250px;
+    background-color: white;
+    box-shadow: 5px 5px 20px 3px rgba(42, 42, 42, 0.84);
+  }
+
+  #text {
+    text-align: center;
+  }
+</style>

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -231,13 +231,15 @@ export default {
     $('#playerTurn').modal('handleUpdate')
 
   },
-  playerModalTrigger() {
-    $('#playerTurn').modal('handleUpdate')
-    $('#playerTurn').modal('show');
+  playerModalTrigger(state) {
+    state.playerTurn = true;
+    // $('#playerTurn').modal('handleUpdate')
+    // $('#playerTurn').modal('show');
   },
-  playerModalHide() {
-    $('#playerTurn').modal('handleUpdate')
-    $('#playerTurn').modal('hide');
+  playerModalHide(state) {
+    state.playerTurn = false;
+    // $('#playerTurn').modal('handleUpdate')
+    // $('#playerTurn').modal('hide');
   },
   coinModalTrigger() {
     $('.coin').modal('handleUpdate');

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -36,7 +36,9 @@ export const store = new Vuex.Store({
       tips: {tutorial: true, fact: true},
       currentOpponents: [],
       coinFlip: 0,
-      coinMsg: 'Evaluating...'
+      coinMsg: 'Evaluating...',
+
+      playerTurn: false
     },
     originalState: {
       players: [],


### PR DESCRIPTION
Fixes #142 
#### Overview of changes

- Changed the player turn and active side modals to simply use divs with fade transitions.
- Lowers the chance of having overlapping modals which leads to undesired results.
-

Reviewer: @johnanvik