### PR TITLE
Side colours

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -25,7 +25,9 @@ body {
   min-height: 100%;
 }
 
-html,body{min-height:100%;}
+html,body{
+  min-height:100%;
+}
 
 body {
   height: 100vh;

--- a/src/components/CoinModal.vue
+++ b/src/components/CoinModal.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="coinStyle" style="top: 20%; left: 50%; margin-left: -200px;">
     <div id="background">
-      <h3>Active Side is: </h3>
+      <h4>Running Instructions in {{ message }} Path</h4>
       <radial-progress-bar :diameter="200"
                            :completed-steps="completedSteps"
                            :total-steps="totalSteps"
@@ -15,10 +15,8 @@
 <script>
   import RadialProgressBar from 'vue-radial-progress'
   export default {
-//    props: ['message', 'completedSteps'],
     data () {
       return {
-//        completedSteps: 0,
         totalSteps: 1,
       }
     },

--- a/src/components/MainComponent.vue
+++ b/src/components/MainComponent.vue
@@ -29,10 +29,10 @@
         <div id="stacks" class="container" style="width: inherit;">
           <div class="row">
             <div class="col-md-6 col-sm-6">
-              <playfield  :trueFalse="true" :activeColour="this.$store.getters.getActiveSide" :playerId="currentPlayerId" :style="trueHighlighted" class="playfieldSides"></playfield>
+              <playfield  :trueFalse="true" :playerId="currentPlayerId" :style="trueSideColour" class="playfieldSides"></playfield>
             </div>
             <div class="col-md-6 col-sm-6">
-              <playfield :trueFalse="false" :activeColour="!this.$store.getters.getActiveSide" :playerId="currentPlayerId" :style="falseHighlighted" class="playfieldSides"></playfield>
+              <playfield :trueFalse="false" :playerId="currentPlayerId" :style="falseSideColour" class="playfieldSides"></playfield>
             </div>
           </div>
         </div>
@@ -115,22 +115,11 @@ export default {
     players() {
         return this.$store.getters.getPlayers.filter(player => player.id !== this.$store.getters.getCurrentPlayerId);
     },
-    trueHighlighted() {
-      if(this.$store.getters.getActiveSide) {
-        return this.highlighted;
-      } else {
-        return ''
-      }
+    trueSideColour() {
+      return this.$store.state.trueSideColour;
     },
-    falseHighlighted() {
-      if(!(this.$store.getters.getActiveSide)) {
-        return this.highlighted;
-      } else {
-        return ''
-      }
-    },
-    highlighted() {
-        return 'box-shadow: 0 0 15px 10px forestgreen';
+    falseSideColour() {
+      return this.$store.state.falseSideColour;
     }
   },
   components: {
@@ -263,6 +252,7 @@ export default {
 .playfieldSides{
   padding: 8px;
   border-radius: 15px;
+  min-height: 375px;
 }
 h1, h2 {
   font-weight: normal;

--- a/src/components/PlayerInfoPanel.vue
+++ b/src/components/PlayerInfoPanel.vue
@@ -24,7 +24,6 @@
                   <card :cardData="card" v-on:cardClicked="cardClicked" @setActiveCard="setActiveCard"></card>
               </li>
           </ul>
-          <h4 class="boolState" >Active Side is: <b>{{ activeSide }}</b></h4>
         </div>
 
         <div id="controls">
@@ -37,13 +36,13 @@
       <div class="container" style="border-top: 1px solid white; padding: 10px;">
         <div class="row">
           <div class="col-md-12">
-            <h4>Score To Win is: <b>{{ $store.getters.getScoreLimit }}</b></h4>
+            <h4>Instructions To Win is: <b>{{ $store.getters.getScoreLimit }}</b></h4>
           </div>
         </div>
         <div class="row">
           <div :class="colSize" v-for="player in players" style="text-align: left">
             <div style="float: left; margin-right: 10px;"><h4><b><a @click="openModal" style="cursor: pointer; color: rgba(10,1,1,0.79);">{{ player.name }}:</a></b></h4></div>
-              <div> True Score: {{ player.trueScore }} <br> False Score: {{ player.falseScore }}</div>
+              <div> True Path: {{ player.trueScore }} Instructions <br> False Path: {{ player.falseScore }} Instructions</div>
           </div>
         </div>
       </div>

--- a/src/components/Playfield.vue
+++ b/src/components/Playfield.vue
@@ -3,7 +3,7 @@
     <div class="row">
       <div class="col-md-12">
         <h5>Total Playfield Score: {{ trueFalse ? score.trueScore : score.falseScore }}</h5></br>
-        <h3 style="text-align: left; margin-left: 40px">if ( Active Side is {{ trueOrFalse }} ) {</h3>
+        <h3 style="text-align: left; margin-left: 40px">if ({{ trueOrFalse }} Path Selected) {</h3>
       </div>
     </div>
     <div class="row">

--- a/src/components/Playfield.vue
+++ b/src/components/Playfield.vue
@@ -93,7 +93,6 @@ export default {
     background-color: #ddd;
     width: 100%;
     height: 90%;
-    overflow-y: scroll;
 }
 
 h1, h2 {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -38,8 +38,9 @@ export default {
         context.commit('coinModalTrigger');
         context.commit('setCoinFlipAnim', 0);
         context.commit('setPlayfieldColour', true);
+        context.state.coinMsg = context.state.activeSide ? 'True' : 'False';
         setTimeout(() => {context.commit('setCoinFlipAnim', 1)}, 200);
-        setTimeout(() => {context.state.coinMsg = context.state.activeSide ? 'True' : 'False'}, 1200);
+        // setTimeout(() => {context.state.coinMsg = context.state.activeSide ? 'True' : 'False'}, 1200);
         setTimeout(() => {
           $('.coin').modal('handleUpdate');
           $('.coin').modal('hide');

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,6 +1,7 @@
 let playerModalTimer = 2;// sec
 let endTurnTimer = 1.5;// sec
 let coinTimer = 2;// sec
+let runTimer = 1;// sec
 
 export default {
   playerTookTurn(context) {
@@ -36,12 +37,17 @@ export default {
         context.commit('checkWin');
         context.commit('coinModalTrigger');
         context.commit('setCoinFlipAnim', 0);
+        context.commit('setPlayfieldColour', true);
         setTimeout(() => {context.commit('setCoinFlipAnim', 1)}, 200);
         setTimeout(() => {context.state.coinMsg = context.state.activeSide ? 'True' : 'False'}, 1200);
         setTimeout(() => {
           $('.coin').modal('handleUpdate');
           $('.coin').modal('hide');
-
+          setTimeout(() => {
+            if(!(context.state.winner)) {
+              context.commit('setPlayfieldColour', false);
+            }
+          }, runTimer * 1000);
         }, coinTimer * 1000);
         if (context.state.winner) {
           setTimeout(() => {
@@ -55,7 +61,7 @@ export default {
             setTimeout(()=> {
               context.commit('playerModalHide');
             }, playerModalTimer * 1000)
-          }, coinTimer * 1000 + 350);
+          }, (coinTimer + runTimer) * 1000 + 350);
         }
         break;
     }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -250,5 +250,19 @@ export default {
   },
   setCoinFlipAnim(state, payload) {
     state.coinFlip = payload;
+  },
+  setPlayfieldColour(state, payload) {
+    if(payload) {
+     if(state.activeSide) {
+       state.trueSideColour = 'background-color: rgba(0, 255, 0, 0.26); box-shadow: 0 0 15px 10px forestgreen';
+       state.falseSideColour = 'rgba(242, 0, 0, 0.36)';
+     } else {
+       state.falseSideColour = 'background-color: rgba(0, 255, 0, 0.26); box-shadow: 0 0 15px 10px forestgreen';
+       state.trueSideColour = 'rgba(242, 0, 0, 0.36)';
+     }
+    } else {
+      state.trueSideColour = 'background-color: cornflowerblue';
+      state.falseSideColour = 'background-color: royalblue';
+    }
   }
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -261,8 +261,8 @@ export default {
        state.trueSideColour = 'rgba(242, 0, 0, 0.36)';
      }
     } else {
-      state.trueSideColour = 'background-color: cornflowerblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)';
-      state.falseSideColour = 'background-color: royalblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)';
+      state.trueSideColour = 'background-color: #80aef7; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)';
+      state.falseSideColour = 'background-color: #80aef7; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)';
     }
   }
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -261,8 +261,8 @@ export default {
        state.trueSideColour = 'rgba(242, 0, 0, 0.36)';
      }
     } else {
-      state.trueSideColour = 'background-color: cornflowerblue';
-      state.falseSideColour = 'background-color: royalblue';
+      state.trueSideColour = 'background-color: cornflowerblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)';
+      state.falseSideColour = 'background-color: royalblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)';
     }
   }
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -37,8 +37,8 @@ export const store = new Vuex.Store({
       currentOpponents: [],
       coinFlip: 0,
       coinMsg: 'Evaluating...',
-      trueSideColour: 'background-color: cornflowerblue',
-      falseSideColour: 'background-color: royalblue'
+      trueSideColour: 'background-color: cornflowerblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)',
+      falseSideColour: 'background-color: royalblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)'
     },
     originalState: {
       players: [],

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -36,7 +36,9 @@ export const store = new Vuex.Store({
       tips: {tutorial: true, fact: true},
       currentOpponents: [],
       coinFlip: 0,
-      coinMsg: 'Evaluating...'
+      coinMsg: 'Evaluating...',
+      trueSideColour: 'background-color: cornflowerblue',
+      falseSideColour: 'background-color: royalblue'
     },
     originalState: {
       players: [],

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -36,9 +36,9 @@ export const store = new Vuex.Store({
       tips: {tutorial: true, fact: true},
       currentOpponents: [],
       coinFlip: 0,
-      coinMsg: 'Evaluating...',
-      trueSideColour: 'background-color: cornflowerblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)',
-      falseSideColour: 'background-color: royalblue; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)'
+      coinMsg: '',
+      trueSideColour: 'background-color: #80aef7; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)',
+      falseSideColour: 'background-color: #80aef7; box-shadow: 0px 3px 15px rgba(0,0,0,0.6)'
     },
     originalState: {
       players: [],


### PR DESCRIPTION
Fixes #159 

#### Overview of changes

- Each side has a different shade of blue for the majority of the game, on coin flip it will turn green and red based on the active side. It stays green and red for 1 sec after the evaluating pop up has ended than goes back to neutral blues. 
- I also added a minimum height to the active sides so that they are the same size until a second row of stacks needs to be added, helps with "choppiness" when switching between players.
- @johnanvik please advise on the colour choice, I can easily try other shades as we discussed. 

Reviewer: @johnanvik