### PR TITLE
Always show hazard or safety when played.

### DIFF
--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -369,14 +369,14 @@ export default {
       });
     } else {
       state.players[payload].hasVirus = true;
-      state.activeCard.flipCardFace;
+      state.activeCard.showFace = true;
       state.players[payload].attackedCards.push(state.activeCard);
     }
     state.players[payload].hadVirus = true;
   },
   givePowerOutage(state,payload) {
     state.players[payload].hasPowerOutage = true;
-    state.activeCard.flipCardFace;
+    state.activeCard.showFace = true;
     state.players[payload].attackedCards.push(state.activeCard);
 
   },
@@ -392,13 +392,13 @@ export default {
 
     if(state.players[payload].hasVirus) {
       state.players[payload].hasVirus = false;
-      state.activeCard.flipCardFace;
+      state.activeCard.showFace = true;
       state.players[payload].attackedCards = state.players[payload].attackedCards.filter(( obj ) => {
         return obj.type !== "VIRUS";
       });
     } else {
       state.players[payload].hasOverclock = true;
-      state.activeCard.flipCardFace;
+      state.activeCard.showFace = true;
       state.players[payload].usedBonusCards.push(state.activeCard);
       state.players[payload].hasHadOverclock = true;
     }
@@ -408,7 +408,7 @@ export default {
     let bonus = 5;
     state.players[payload].hasFirewall = true;
     state.players[payload].hasPowerOutage = false;
-    state.activeCard.flipCardFace;
+    state.activeCard.showFace = true;
     state.players[payload].usedBonusCards.push(state.activeCard);
     state.players[payload].updateBonus(bonus,bonus);
     state.players[payload].protectionCardsBonus += bonus;
@@ -424,7 +424,7 @@ export default {
     state.players[payload].attackedCards = state.players[payload].attackedCards.filter(( obj ) => {
       return obj.type !== "POWEROUTAGE";
     });
-    state.activeCard.flipCardFace;
+    state.activeCard.showFace = true;
     state.players[payload].usedBonusCards.push(state.activeCard);
     state.players[payload].updateBonus(bonus,bonus);
     state.players[payload].protectionCardsBonus += bonus;
@@ -439,7 +439,7 @@ export default {
     state.players[payload].attackedCards = state.players[payload].attackedCards.filter(( obj ) => {
       return obj.type !== "VIRUS";
     });
-    state.activeCard.flipCardFace;
+    state.activeCard.showFace = true;
     state.players[payload].usedBonusCards.push(state.activeCard);
     state.players[payload].updateBonus(bonus,bonus);
     state.players[payload].protectionCardsBonus += bonus;


### PR DESCRIPTION
Fixes #331

#### Overview of changes
- Force safety and hazards cards to show when they are played.

Reviewer: @JaceRiehl 
