### PR TITLE
Allows the user to add battery backups without having a power outage.

### DIFF
--- a/src/classes/Models/Player.js
+++ b/src/classes/Models/Player.js
@@ -26,6 +26,7 @@ export default class Player {
     this.hasAntiVirus = false
     this.hasFirewall = false
     this.hasPowerOutage = false
+    this.hasBatteryBackup = false
     this.isAi = isAi
     this.hasOverclock = false
     this.hasVirus = false

--- a/src/components/Modals/CardModals/BatteryBackup.vue
+++ b/src/components/Modals/CardModals/BatteryBackup.vue
@@ -10,7 +10,7 @@
         <div class="modal-body">
           <div class="container col-lg-12">
             <div class="row">
-              <p style="font-size: 24px;">Do you want to use the Battery Backup to negate a power outage?</p>
+              <p style="font-size: 24px;">Do you want to use the Battery Backup to negate a power outage or prevent your next one?</p>
             </div>
           </div>
         </div>
@@ -93,7 +93,7 @@
       },
       playerCanUse () {
         let player = this.getCurrentPlayer()
-        return !player.hasPowerOutage
+        return player.hasBatteryBackup
       }
     },
     created () {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -393,16 +393,29 @@ export default {
     state.players[payload].hadVirus = true
   },
   givePowerOutage (state, payload) {
-    state.players[payload].hasPowerOutage = true
-    state.activeCard.showFace = true
-    state.players[payload].attackedCards.push(state.activeCard)
+    if (state.players[payload].hasBatteryBackup) {
+      state.players[payload].hasBatteryBackup = false
+      state.players[payload].usedBonusCards = state.players[payload].usedBonusCards.filter((obj) => {
+        return obj.type !== 'BATTERYBACKUP'
+      })
+    } else {
+      state.players[payload].hasPowerOutage = true
+      state.activeCard.showFace = true
+      state.players[payload].attackedCards.push(state.activeCard)
+    }
   },
   giveBatteryBackup (state, payload) {
-    state.players[payload].hasPowerOutage = false
-    state.players[payload].attackedCards = state.players[payload].attackedCards.filter((obj) => {
-      return obj.type !== 'POWEROUTAGE'
-    })
-    state.players[payload].updateBonus(1, 1)
+    if (state.players[payload].hasPowerOutage) {
+      state.players[payload].hasPowerOutage = false
+      state.activeCard.showFace = true
+      state.players[payload].attackedCards = state.players[payload].attackedCards.filter((obj) => {
+        return obj.type !== 'POWEROUTAGE'
+      })
+    } else {
+      state.players[payload].hasBatteryBackup = true
+      state.activeCard.showFace = true
+      state.players[payload].usedBonusCards.push(state.activeCard)
+    }
   },
   giveOverclock (state, payload) {
     // state.players[payload].updateOverclock();


### PR DESCRIPTION
Fixes #409 

#### Overview of changes

- Allows the user to play a battery backup without a power outage already being played.

Reviewer: @johnanvik
